### PR TITLE
Another approach with multiple workflows.

### DIFF
--- a/.circleci/build.yml
+++ b/.circleci/build.yml
@@ -5,40 +5,59 @@
 # https://circleci.com/docs/language-go/ for more details
 version: 2.1
 
-# define this file as the setup phase of your dynamic configuration
-setup: true
-
-# invoke the continuation orb to make the continuation/continue command available
-orbs:
-  continuation: circleci/continuation@1
+# Parameters passed from setup workflow on config.yml
+parameters:
+  commit_message:
+    type: string
+    default: ''
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
 jobs:
-  setup:
+  build:
     # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
     # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/docs/configuration-reference/#executor-job
     docker:
       # Specify the version you desire here
       # See: https://circleci.com/developer/images/image/cimg/go
       - image: cimg/go:1.21
-      
+
     # Add steps to the job
     # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps
     steps:
       # Checkout the code as the first step.
-      - checkout
       - run:
+          command: echo "commit message << pipeline.parameters.commit_message >>"
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-v4-{{ checksum "go.sum" }}
+      - run:
+          name: Install Dependencies
+          command: go mod download
+      - save_cache:
+          key: go-mod-v4-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+      - run:
+          name: Run tests
           command: |
-            export COMMIT_MESSAGE=$(git log --format=oneline -n 1 $CIRCLE_SHA1)
-            echo "{\"commit_message\": \"$COMMIT_MESSAGE\"}" >> set-up-params.json
-      - continuation/continue:
-          parameters: set-up-params.json
-          configuration_path: .circleci/build.yml
+            mkdir -p /tmp/test-reports
+            gotestsum --junitfile /tmp/test-reports/unit-tests.xml
+      - store_test_results:
+          path: /tmp/test-reports
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  setup:
+  sample:
+    when:
+      and:
+        - matches:
+            pattern: "^release.+"
+            value: << pipeline.git.branch >>
+        - matches:
+            pattern: "^(?:(?!NOCIRCLECI).)*$"
+            value: << pipeline.parameters.commit_message >>
     jobs:
-      - setup
+      - build


### PR DESCRIPTION
I thought about the original way, which read git commit message from CLI and then use it in workflow logic conditions, but it seems impossible, since:

1. The logic conditions is processed in compilation time, not run time.
2. `git log` wont work without `checkout` the source.

In this workaround,

1. I created a `setup` workflow which used to get the commit message and then pass it to the `build` workflow.
2. In the `build` workflow, we check if the git commit message and then decide whether to proceed the job.

![image](https://github.com/user-attachments/assets/c1a6b918-0ee5-440c-add0-7b587eeab05b)

https://app.circleci.com/pipelines/circleci/qHXqJBvUMYDAjmxWMtFb8/2a96639b-8816-46f8-bf48-f77dba6fbeb1?branch=release-3